### PR TITLE
Update python supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ matrix:
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
+    - python: "3.7"
+      env: TOXENV=py37
+    - python: "3.8"
+      env: TOXENV=py38
     - python: "2.7"
       env: TOXENV=py27
     - python: "3.6"

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,8 @@ classifier =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
-
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 [files]
 packages =
     pycmus

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py36,py35,py27,pep8
+envlist = py38,py37,py36,py35,py27,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This commit updates the list of supported python versions. Pycmus
supports python 2.7 and python >= 3.5 but we only were advertising
python 3.5 and 3.6 support, additionally we were only testing 3.5 and
3.6. This updates all the package metadata and ads ci and tox config to
reflect all the supported versions.